### PR TITLE
Remove host_key_checking=False from ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,5 @@
 [defaults]
 display_skipped_hosts=False
 localhost_warning=False
-host_key_checking=False
 retry_files_enabled=False
 roles_path=./ansible/roles:./common/ansible/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles


### PR DESCRIPTION
We only use connection: local and security-wise it is generally
preferrable to not have this set to False.
